### PR TITLE
 [RFR] Display helping tips to player

### DIFF
--- a/src/game/Box.js
+++ b/src/game/Box.js
@@ -11,6 +11,8 @@ export default class Box extends Component {
         enabled: PropTypes.bool,
         selected: PropTypes.bool,
         winningBox: PropTypes.bool,
+        badBox: PropTypes.bool,
+        goodBox: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -26,6 +28,8 @@ export default class Box extends Component {
             onPress,
             selected,
             winningBox,
+            badBox,
+            goodBox,
         } = this.props;
         const pieceImageArray = initImagesRequire();
         return (
@@ -35,7 +39,8 @@ export default class Box extends Component {
                 style={[
                     boxSize,
                     styles.box,
-                    winningBox ? styles.winning : '',
+                    winningBox || goodBox ? styles.winning : '',
+                    badBox ? styles.loosing : '',
                     enabled ? styles.enabled : '',
                     selected ? styles.selected : '',
                 ]}
@@ -75,6 +80,7 @@ const normalBoxColor = 'lightblue';
 const winningBoxColor = 'green';
 const clickedBoxColor = '#6699ff';
 const selectedBoxColor = '#80ffbf';
+const loosingBoxColor = 'orange';
 
 const styles = StyleSheet.create({
     box: {
@@ -87,6 +93,9 @@ const styles = StyleSheet.create({
     },
     winning: {
         backgroundColor: winningBoxColor,
+    },
+    loosing: {
+        backgroundColor: loosingBoxColor,
     },
     enabled: {
         opacity: 1,

--- a/src/game/GameScreen.js
+++ b/src/game/GameScreen.js
@@ -111,6 +111,7 @@ export default class GameScreen extends React.Component {
                         <Grid
                             onPress={this.handleGridPress}
                             grid={game.grid}
+                            goodPlaces={game.winningPlaces}
                             winningLine={game.winningLine}
                             readOnly={game.locked}
                         />
@@ -146,6 +147,12 @@ export default class GameScreen extends React.Component {
                             onPress={this.handleRemainingListPress}
                             list={game.allPieces}
                             selectedPiece={game.selectedPiece}
+                            badPieces={
+                                game.winningLine.length == 0 &&
+                                game.selectedPiece == 0
+                                    ? game.winningPieces
+                                    : []
+                            }
                             readOnly={game.locked}
                         />
                     </View>

--- a/src/game/Grid.js
+++ b/src/game/Grid.js
@@ -10,6 +10,7 @@ export default class Grid extends Component {
         grid: PropTypes.array.isRequired,
         winningLine: PropTypes.array.isRequired,
         readOnly: PropTypes.bool,
+        goodPlaces: PropTypes.array.isRequired,
     };
 
     static defaultProps = {
@@ -17,7 +18,7 @@ export default class Grid extends Component {
     };
 
     render() {
-        const { grid, readOnly, onPress, winningLine } = this.props;
+        const { grid, readOnly, onPress, winningLine, goodPlaces } = this.props;
 
         return (
             <View style={styles.column}>
@@ -36,6 +37,11 @@ export default class Grid extends Component {
                                         winningBox={
                                             winningLine.indexOf(boxValue) >= 0
                                         }
+                                        goodPlace={this.positionInclude(
+                                            goodPlaces,
+                                            boxKey,
+                                            rowKey,
+                                        )}
                                     />
                                 );
                             })}
@@ -45,6 +51,12 @@ export default class Grid extends Component {
             </View>
         );
     }
+
+    positionInclude = (placesList, x, y) => {
+        return placesList.some(place => {
+            return place[0] == y && place[1] == x;
+        });
+    };
 }
 
 const styles = StyleSheet.create({

--- a/src/game/GridBox.js
+++ b/src/game/GridBox.js
@@ -11,6 +11,7 @@ export default class GridBox extends Component {
         boxValue: PropTypes.string.isRequired,
         enabled: PropTypes.bool,
         winningBox: PropTypes.bool.isRequired,
+        goodPlace: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -25,7 +26,7 @@ export default class GridBox extends Component {
     };
 
     render() {
-        const { boxValue, enabled, x, y, winningBox } = this.props;
+        const { boxValue, enabled, x, y, winningBox, goodPlace } = this.props;
 
         return (
             <Box
@@ -35,6 +36,7 @@ export default class GridBox extends Component {
                 label={'gridbox_x' + String(x) + '_y' + String(y)}
                 onPress={this.handlePress}
                 winningBox={winningBox}
+                goodBox={goodPlace}
             />
         );
     }

--- a/src/game/RemainingBox.js
+++ b/src/game/RemainingBox.js
@@ -9,6 +9,7 @@ export default class RemainingBox extends Component {
         boxValue: PropTypes.string.isRequired,
         enabled: PropTypes.bool,
         selected: PropTypes.bool,
+        badPiece: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -23,7 +24,7 @@ export default class RemainingBox extends Component {
     };
 
     render() {
-        const { boxValue, enabled, selected } = this.props;
+        const { boxValue, enabled, selected, badPiece } = this.props;
 
         return (
             <Box
@@ -33,6 +34,7 @@ export default class RemainingBox extends Component {
                 label={'remainingbox'}
                 onPress={this.handlePress}
                 selected={selected}
+                badBox={badPiece}
             />
         );
     }

--- a/src/game/RemainingList.js
+++ b/src/game/RemainingList.js
@@ -10,6 +10,7 @@ export default class RemainingList extends Component {
         list: PropTypes.object.isRequired,
         readOnly: PropTypes.bool,
         selectedPiece: PropTypes.number,
+        badPieces: PropTypes.array.isRequired,
     };
 
     static defaultProps = {
@@ -17,7 +18,13 @@ export default class RemainingList extends Component {
     };
 
     render() {
-        const { list, readOnly, onPress, selectedPiece } = this.props;
+        const {
+            list,
+            readOnly,
+            onPress,
+            selectedPiece,
+            badPieces,
+        } = this.props;
         return (
             <View style={styles.row}>
                 {Object.keys(list).map(pieceKey => {
@@ -29,6 +36,9 @@ export default class RemainingList extends Component {
                                 enabled={!readOnly}
                                 onPress={onPress}
                                 selected={selectedPiece == list[pieceKey].id}
+                                badPiece={
+                                    badPieces.indexOf(list[pieceKey].id) >= 0
+                                }
                             />
                         );
                     }

--- a/tests/Components.test.js
+++ b/tests/Components.test.js
@@ -33,6 +33,7 @@ describe('Components tests', () => {
                 grid={game.grid}
                 winningLine={[]}
                 readOnly={false}
+                goodPlaces={[]}
             />,
         );
 


### PR DESCRIPTION
follow #9 
follow also PR #12 from quarto-synfony (Helping mode for API )

https://trello.com/c/5uJpDl2n
https://trello.com/c/YtMmbexb

![image](https://user-images.githubusercontent.com/39904906/42291129-11ae4864-7fca-11e8-957f-fa6e0da7f93b.png)


Places to choose to win are display in green

![image](https://user-images.githubusercontent.com/39904906/42291148-3b9b73fe-7fca-11e8-895a-d5c43bcf5c58.png)

Pieces to not selected to not loose are displayed in orange